### PR TITLE
unset flag when encoding array's elements

### DIFF
--- a/xencoder.h
+++ b/xencoder.h
@@ -81,7 +81,7 @@ public:
         doc_type *dt = (doc_type*)this;
         dt->ArrayBegin(key, ext);
         for (size_t i=0; i<N; ++i) {
-            dt->encode(dt->IndexKey(i), val[i], ext);
+            dt->encode(dt->IndexKey(i), val[i], NULL);
         }
         dt->ArrayEnd(key, ext);
         return true;
@@ -222,7 +222,7 @@ public:
         dt->ArrayBegin(key, ext);
         size_t i = 0;
         for (typename LIST::const_iterator it=val.begin(); it!=val.end(); ++it, ++i) {
-            dt->encode(dt->IndexKey(i), *it, ext);
+            dt->encode(dt->IndexKey(i), *it, NULL);
         }
         dt->ArrayEnd(key, ext);
         return true;
@@ -237,7 +237,7 @@ public:
         doc_type *dt = (doc_type*)this;
         dt->ObjectBegin(key, ext);
         for (typename Map::const_iterator it=val.begin(); it!=val.end(); ++it) {
-            dt->encode(convert(it->first).c_str(), it->second, ext);
+            dt->encode(convert(it->first).c_str(), it->second, NULL);
         }
         dt->ObjectEnd(key, ext);
         return true;
@@ -252,7 +252,7 @@ public:
         doc_type *dt = (doc_type*)this;
         dt->ObjectBegin(key, ext);
         for (typename Map::const_iterator it=val.begin(); it!=val.end(); ++it) {
-            dt->encode(convert(it.key()).c_str(), it.value(), ext);
+            dt->encode(convert(it.key()).c_str(), it.value(), NULL);
         }
         dt->ObjectEnd(key, ext);
         return true;


### PR DESCRIPTION
avoid json omitting empty string in array(vector) when flag is OE(omitempty)

for example:
'[]' can be omitted
'["", ""]' remains the same instead of becoming '[]'